### PR TITLE
Add Makefile and draft of README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,117 @@
 # Normalize line endings
 * text=auto eol=lf
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as text by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.gz       binary
+*.tar      binary
+*.tgz      binary
+*.zip      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+# Sources
+*.c     text diff=cpp
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.c++   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=cpp
+*.h++   text diff=cpp
+*.hh    text diff=cpp
+
+# Compiled Object files
+*.slo   binary
+*.lo    binary
+*.o     binary
+*.obj   binary
+
+# Precompiled Headers
+*.gch   binary
+*.pch   binary
+
+# Compiled Dynamic libraries
+*.so    binary
+*.dylib binary
+*.dll   binary
+
+# Compiled Static libraries
+*.lai   binary
+*.la    binary
+*.a     binary
+*.lib   binary
+
+# Executables
+*.exe   binary
+*.out   binary
+*.app   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-* text eol=lf
+# Normalize line endings
+* text=auto eol=lf

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ debug=
 POET_HOME=../../../POET/trunk
 POET=pcg
 
-now:
+all:
 	$(POET) $(debug) -L$(POET_HOME)/lib -pinputFile=testfiles/$(input) -poutputFile=$(output) -pspecFile=semantics/abstractions.spec abstractionAnalysis.pt
 
 stack:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+input=SinglyLinkedList.h_orig
+output=
+debug=
+POET_HOME=../../../POET/trunk
+POET=pcg
+
+now:
+	$(POET) $(debug) -L$(POET_HOME)/lib -pinputFile=testfiles/$(input) -poutputFile=$(output) -pspecFile=semantics/abstractions.spec abstractionAnalysis.pt
+
+stack:
+	$(POET) $(debug) -L$(POET_HOME)/lib -pinputFile=testfiles/$(input) -poutputFile=$(output) -pspecFile=semantics/abstractions_stack.spec abstractionAnalysis.pt
+
+queue:
+	$(POET) $(debug) -L$(POET_HOME)/lib -pinputFile=testfiles/$(input) -poutputFile=$(output) -pspecFile=semantics/abstractions_queue.spec abstractionAnalysis.pt

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 
 ## About the project
 
-[Brief explanation of goal of project]
+This project aims to automatically discover the higher-level semantics of C++ classes by classifying the classes as abstractions, such as, stacks and queues.
 
 ### Current status
 
 #### First prototype
 
-[Brief description of current status]
+Currently, the project is in the prototyping stage. The aim is to do an initial implementation of the algorithm design.
 
 ### Repository
 
 - `research/abstractionAnalysis/` directory contains all implementations and necessary files for this project
 - `research/abstractionAnalysis/testfiles` directory contains test input files and expected outputs
 - `research/abstractionAnalysis/semantics` directory contains semantic specification files used by the parser
-- `research/abstractionAnalysis/design` directory contains initial prototype design files (should it be included in public repository?)
 
 ## Steps
 
-- Install POET (if you don't have it in your local machine already)
+- Download POET
   - [Repository](https://github.com/qingyi-yan/POET)
-  - [Handbook](http://www.cs.uccs.edu/~qyi/poet/documents/manual.pdf)
-- Go to the `research/abstractionAnalysis/` directory and run `make all`
-  - Run `make stack` to only analyze the given Singly Linked List against a stack abstraction
-  - Run `make queue` to only analyze the given Singly Linked List against a queue abstraction
+  - Place the downloaded `POET` directory in the same directory as `abstraction-analysis`
+  - Alternatively, you may update the `POET_HOME` variable in the Makefile to point to your `POET` directory location
+- Install POET following the directions in the [Handbook](http://www.cs.uccs.edu/~qyi/poet/documents/manual.pdf)
+- Go to the `research/abstractionAnalysis/` directory and run `make all` or
+  - `make stack` to only analyze the given Singly Linked List against a stack abstraction
+  - `make queue` to only analyze the given Singly Linked List against a queue abstraction
 
 ## Contribution guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-<*Owners: *>
+
+## About the project
+
+[Brief explanation of goal of project]
+
+### Current status
+
+#### First prototype
+
+[Brief description of current status]
+
+### Repository
+
+- `research/abstractionAnalysis/` directory contains all implementations and necessary files for this project
+- `research/abstractionAnalysis/testfiles` directory contains test input files and expected outputs
+- `research/abstractionAnalysis/semantics` directory contains semantic specification files used by the parser
+- `research/abstractionAnalysis/design` directory contains initial prototype design files (should it be included in public repository?)
+
+## Steps
+
+- Install POET (if you don't have it in your local machine already)
+  - [Repository](https://github.com/qingyi-yan/POET)
+  - [Handbook](http://www.cs.uccs.edu/~qyi/poet/documents/manual.pdf)
+- Go to the `research/abstractionAnalysis/` directory and run `make all`
+  - Run `make stack` to only analyze the given Singly Linked List against a stack abstraction
+  - Run `make queue` to only analyze the given Singly Linked List against a queue abstraction
+
+## Contribution guidelines
+
+- Do not work on the `main` branch. Choose to use a working branch instead
+- Commit locally often
+- Rebase before pushing to remote
+- When ready for review, open a pull request (PR) to merge to the `main` branch: try to keep each PR limited in scope and goal
+- Once PR is open
+  - Keep each incremental commit to let reviewers see commits as comments get addressed
+  - Reviewer(s) will mark issues as **Resolved**
+  - Requestor will merge once at least 2 reviewers have approved the request
+- When approved for merging, do one final rebase to squash all comments from PR: keep 1 commit per PR


### PR DESCRIPTION
Address AA-11, AA-7

Summary:
- Add Makefile
- Add initial draft of README file specifying requirements, steps, and contribution guidelines
- .gitattributes file to normalize linebreaks between contributors to use LF instead of CRLF